### PR TITLE
Fix Eisvogel PDF frontmatter error

### DIFF
--- a/convert.php
+++ b/convert.php
@@ -4,6 +4,14 @@ session_start();
 $uploadDir = __DIR__ . '/uploads/';
 $outputDir = __DIR__ . '/output/';
 
+// Ensure working directories exist
+if (!is_dir($uploadDir)) {
+    mkdir($uploadDir, 0777, true);
+}
+if (!is_dir($outputDir)) {
+    mkdir($outputDir, 0777, true);
+}
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Location: index.php');
     exit;
@@ -266,11 +274,13 @@ try {
             // Ensure eisvogel template works with book class by setting frontmatter support
             if ($template === 'eisvogel') {
                 $pandocArgs[] = "-V";
-                $pandocArgs[] = "titlepage=true"; $pandocArgs[] = "-V"; $pandocArgs[] = "frontmatter=false";
-                            $pandocArgs[] = "-V";
+                $pandocArgs[] = "titlepage=true";
+                $pandocArgs[] = "-V";
                 $pandocArgs[] = "frontmatter=false";
-                $latexHeader = "\providecommand{\frontmatter}[0]{};\providecommand{\mainmatter}[0]{};";
-                $headerFile = $uploadDir . $timestamp . '_custom_header.tex';
+                $latexHeader = "\\providecommand{\\frontmatter}{}\n" .
+                    "\\providecommand{\\mainmatter}{}\n" .
+                    "\\providecommand{\\backmatter}{}";
+                $headerFile = $outputDir . $timestamp . '_custom_header.tex';
                 file_put_contents($headerFile, $latexHeader);
                 $pandocArgs[] = "--include-in-header=" . escapeshellarg($headerFile);
             }


### PR DESCRIPTION
## Summary
- ensure upload and output directories exist
- define custom frontmatter commands in generated header when using Eisvogel

## Testing
- `php -l convert.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6848b14872f88333afbd7b8ea09daaf0